### PR TITLE
Add encode URI to match the decodeURI on TiddlyServer

### DIFF
--- a/TiddlyServerUploadPlugin.js
+++ b/TiddlyServerUploadPlugin.js
@@ -52,7 +52,7 @@ config.options.chkHttpReadOnly = false;
 function UploadToTiddlyServer(filePath, content) {
   if (config.options.chkEnableUpload) {
     config.saveByDownload = true;
-    var url = filePath.replace(/\\\\/, 'http://').replace(/\\/g, '/');
+    var url = encodeURI(filePath.replace(/\\\\/, 'http://').replace(/\\/g, '/'));
     var data = decodeURIComponent(escape(content));
     var xhr = new XMLHttpRequest();
     xhr.onload = () => {


### PR DESCRIPTION
Files with percent codes (%20) and spaces in their file path need to be URI encoded exactly one time before making the request.